### PR TITLE
Fix linking on Windows for upcoming version of Rtools.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,6 +1,19 @@
-PKG_CPPFLAGS = -I./include -I$(R_TOOLS_SOFT)/include/freetype2 -I./libming
-PKG_LIBS = -L./libming -lming -lfreetype -lharfbuzz -lfreetype -lpng -lz -lbz2
+PKG_CPPFLAGS = -I./include -I./libming
+PKG_LIBS = -L./libming -lming
 
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBBROTLI = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
+  PKG_LIBS += -lfreetype -lharfbuzz -lfreetype $(LIBBROTLI) -lpng -lz -lbz2
+  FTFLAGS = -I$(R_TOOLS_SOFT)/include/freetype2
+else
+  PKG_LIBS += $(shell pkg-config --libs freetype2)
+  FTFLAGS = $(shell pkg-config --cflags freetype2)
+
+  # work-around for freetype2 pkg-config file in Rtools43
+  FTFLAGS += -I$(R_TOOLS_SOFT)/include/freetype2
+endif
+
+PKG_CPPFLAGS += $(FTFLAGS)
 
 .PHONY: all deps clean
 
@@ -9,7 +22,7 @@ all: $(SHLIB)
 $(SHLIB): libming/libming.a
 
 libming/libming.a:
-	cd libming && $(MAKE) all CC="$(CC)" AR="$(AR)" CPPFLAGS="-I$(R_TOOLS_SOFT)/include/freetype2 $(R_XTRA_CPPFLAGS)" CFLAGS="$(ALL_CFLAGS)"
+	cd libming && $(MAKE) all CC="$(CC)" AR="$(AR)" CPPFLAGS="$(FTFLAGS) $(R_XTRA_CPPFLAGS)" CFLAGS="$(ALL_CFLAGS)"
 
 clean:
 	$(RM) *.o


### PR DESCRIPTION
This fixes the package to link on Windows with an upcoming version of Rtools, where one more dependency (brotli) is needed. It also switches to using pkg-config, when available, so that such changes will less likely be needed in the future when Rtools is updated.